### PR TITLE
Fixed reading large dlt messages from file

### DIFF
--- a/src/pydlt/file.py
+++ b/src/pydlt/file.py
@@ -67,18 +67,6 @@ class DltFileReader:
             raise StopIteration()
         return message
 
-    def _read_bytes(self, size: int) -> bytes:
-        """reads size bytes from the file
-        (self._file.read() might read less than requested)
-        """
-        result = b""
-        while len(result) < size:
-            chunk = self._file.read(size - len(result))
-            if len(chunk) == 0:
-                break
-            result += chunk
-        return result
-
     def read_message(self) -> Optional[DltMessage]:
         """Read 1 DLT message from file.
 
@@ -86,7 +74,7 @@ class DltFileReader:
             Optional[DltMessage]: DLT message or None if not enough data to read
         """
         min_length = StorageHeader.DATA_LENGTH + StandardHeader.DATA_MIN_LENGTH
-        msg_data = self._read_bytes(min_length)
+        msg_data = self._file.read(min_length)
 
         if len(msg_data) < min_length:
             return None
@@ -94,7 +82,7 @@ class DltFileReader:
             StandardHeader.STRUCT_MIN_FORMAT, msg_data, StorageHeader.DATA_LENGTH
         )[2]
         msg_length = StorageHeader.DATA_LENGTH + length
-        msg_data += self._read_bytes(msg_length - min_length)
+        msg_data += self._file.read(msg_length - min_length)
         if len(msg_data) < msg_length:
             return None
         return DltMessage.create_from_bytes(msg_data, True)

--- a/src/pydlt/message.py
+++ b/src/pydlt/message.py
@@ -91,6 +91,16 @@ class DltMessage:
         self.ext_header = ext_header
         self.payload = payload
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (
+                self.str_header == other.str_header
+                and self.std_header == other.std_header
+                and self.ext_header == other.ext_header
+                and self.payload == other.payload
+            )
+        return False
+
     def __str__(self) -> str:
         """Get overview of the message.
 

--- a/src/pydlt/payload.py
+++ b/src/pydlt/payload.py
@@ -18,6 +18,11 @@ class Payload(ABC):
     def __str__(self) -> str:
         return self._to_str()
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.to_bytes(False) == other.to_bytes(False)
+        return False
+
     @classmethod
     @abstractmethod
     def create_from_bytes(cls, data: bytes, msb_fitst: bool) -> "Payload":

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -54,6 +54,28 @@ def test_file_context_manager():
     assert reader.closed is True
 
 
+def test_file_read_large_message():
+    path = TEST_RESULTS_DIR_PATH / Path(f"{sys._getframe().f_code.co_name}.dlt")
+
+    msg1 = DltMessage.create_verbose_message(
+        [ArgumentString("0123456789" * 6000)],
+        MessageType.DLT_TYPE_LOG,
+        MessageLogInfo.DLT_LOG_INFO,
+        "App",
+        "Ctx",
+        message_counter=0,
+        str_header=StorageHeader(0, 0, "Ecu"),
+    )
+
+    with DltFileWriter(path) as writer:
+        writer.write_messages([msg1])
+
+    with DltFileReader(path) as reader:
+        msg = reader.read_message()
+        assert msg is not None
+        assert msg1 == msg
+
+
 def test_file_list_iterator():
     path = TEST_RESULTS_DIR_PATH / Path(f"{sys._getframe().f_code.co_name}.dlt")
 


### PR DESCRIPTION
`peek()` might read less bytes than requested