### PR TITLE
Support Bool arguments without type length

### DIFF
--- a/src/pydlt/payload.py
+++ b/src/pydlt/payload.py
@@ -277,11 +277,9 @@ class Argument(ABC):
         type_info = struct.unpack(f"{endian}I", data[: cls._TYPE_INFO_LENGTH])[0]
         type_info_base = type_info & MASK_BASE_TYPE
         if type_info_base == TypeInfo.TYPE_BOOL:
-            type_info_length = type_info & MASK_TYPE_LENGTH
-            if type_info_length == TypeInfo.TYPE_LENGTH_8BIT:
-                return ArgumentBool.from_data_payload(
-                    data[cls._TYPE_INFO_LENGTH :], msb_first
-                )
+            return ArgumentBool.from_data_payload(
+                data[cls._TYPE_INFO_LENGTH :], msb_first
+            )
         elif type_info_base == TypeInfo.TYPE_SIGNED:
             type_info_length = type_info & MASK_TYPE_LENGTH
             if type_info_length == TypeInfo.TYPE_LENGTH_8BIT:
@@ -363,7 +361,7 @@ class Argument(ABC):
         """
         raise NotImplementedError
 
-    def to_bytes(self, msb_first: Optional[bool] = None) -> bytes:
+    def to_bytes(self, msb_first: Optional[bool] = False) -> bytes:
         """Convert to data bytes.
 
         Args:

--- a/src/pydlt/payload.py
+++ b/src/pydlt/payload.py
@@ -361,7 +361,7 @@ class Argument(ABC):
         """
         raise NotImplementedError
 
-    def to_bytes(self, msb_first: Optional[bool] = False) -> bytes:
+    def to_bytes(self, msb_first: Optional[bool] = None) -> bytes:
         """Convert to data bytes.
 
         Args:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -380,6 +380,14 @@ def test_message_verbose_payload_bool():
     assert cast(ArgumentBool, dlt_message2.verbose_payload.arguments[1]).data is True
 
 
+def test_bool_payload_without_type_length():
+    b1 = ArgumentBool(True)
+    dlt_bytes = bytearray(b1.to_bytes(False))
+    # clear the TypeInfo.TYPE_LENGTH_8BIT flag
+    dlt_bytes[0] = 0x10
+    assert Argument.create_from_bytes(dlt_bytes, False).data is True
+
+
 def test_message_verbose_payload_uint():
     path = TEST_RESULTS_DIR_PATH / Path(f"{sys._getframe().f_code.co_name}.dlt")
 


### PR DESCRIPTION
Some (standard) dlt implementations do not set the TYLE bits for boolean arguments.